### PR TITLE
#6 extract dependencies (and versions) into separate files

### DIFF
--- a/build.sbt
+++ b/build.sbt
@@ -1,9 +1,3 @@
-val Versions = new {
-  val Akka      = "2.4.14"
-  val Scalatest = "3.0.1"
-  val JGit      = "4.5.0.201609210915-r"
-}
-
 organization := "Scalatron"
 
 name := "Scalatron"
@@ -53,7 +47,7 @@ lazy val ScalatronCore = project
   .settings(
     commonSettings,
     lintingSettings,
-    libraryDependencies += "com.typesafe.akka" %% "akka-actor" % Versions.Akka,
+    libraryDependencies ++= Dependencies.core,
     assemblyJarName in assembly := "ScalatronCore.jar"
   )
 
@@ -63,7 +57,6 @@ lazy val BotWar = project
   .settings(
     commonSettings,
     lintingSettings,
-    libraryDependencies += "com.typesafe.akka" %% "akka-actor" % Versions.Akka,
     assemblyJarName in assembly := "BotWar.jar"
   )
 
@@ -73,17 +66,7 @@ lazy val Scalatron = project
   .settings(
     commonSettings,
     lintingSettings,
-    libraryDependencies ++= Seq(
-      "org.scala-lang"              % "scala-compiler"               % scalaVersion.value,
-      "com.typesafe.akka"           %% "akka-actor"                  % Versions.Akka,
-      "org.eclipse.jetty.aggregate" % "jetty-webapp"                 % "7.6.21.v20160908" intransitive (),
-      "com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider"  % "2.8.5",
-      "com.sun.jersey"              % "jersey-bundle"                % "1.19.3" exclude ("javax.ws.rs", "jsr311-api"),
-      "javax.servlet"               % "servlet-api"                  % "2.5",
-      "org.eclipse.jgit"            % "org.eclipse.jgit"             % Versions.JGit,
-      "org.eclipse.jgit"            % "org.eclipse.jgit.http.server" % Versions.JGit,
-      "org.scalatest"               %% "scalatest"                   % Versions.Scalatest % Test
-    ),
+    libraryDependencies ++= Dependencies.scalatron(scalaVersion.value),
     assemblyJarName in assembly := "Scalatron.jar" // , logLevel in assembly := Level.Debug
   )
 
@@ -92,10 +75,7 @@ lazy val ScalatronCLI = project
   .settings(
     commonSettings,
     lintingSettings,
-    libraryDependencies ++= Seq(
-      "org.apache.httpcomponents" % "httpclient"                % "4.5.2",
-      "org.scala-lang.modules"    %% "scala-parser-combinators" % "1.0.4"
-    ),
+    libraryDependencies ++= Dependencies.cli,
     assemblyJarName in assembly := "ScalatronCLI.jar"
   )
 
@@ -103,9 +83,7 @@ lazy val ScalaMarkdown = project
   .in(file("ScalaMarkdown"))
   .settings(
     commonSettings,
-    libraryDependencies ++= Seq(
-      "org.scalatest" %% "scalatest" % Versions.Scalatest % Test
-    ),
+    libraryDependencies ++= Dependencies.markdown,
     assemblyJarName in assembly := "ScalaMarkdown.jar"
   )
 

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -15,7 +15,8 @@ object Dependencies {
     "javax.servlet"               % "servlet-api"                  % ServletApi,
     "org.eclipse.jgit"            % "org.eclipse.jgit"             % JGit,
     "org.eclipse.jgit"            % "org.eclipse.jgit.http.server" % JGit,
-    "org.scalatest"               %% "scalatest"                   % Scalatest % Test
+    "org.scalatest"               %% "scalatest"                   % Scalatest % Test,
+    "org.specs2"                  %% "specs2-core"                 % Specs2    % Test
   )
 
   val markdown = Seq(

--- a/project/Dependencies.scala
+++ b/project/Dependencies.scala
@@ -1,0 +1,30 @@
+import sbt._
+import Versions._
+
+object Dependencies {
+  val cli = Seq(
+    "org.apache.httpcomponents" % "httpclient"                % HttpClient,
+    "org.scala-lang.modules"    %% "scala-parser-combinators" % ParserCombinators
+  )
+
+  def scalatron(scalaVersion: String) = Seq(
+    "org.scala-lang"              % "scala-compiler"               % scalaVersion,
+    "org.eclipse.jetty.aggregate" % "jetty-webapp"                 % Jetty intransitive (),
+    "com.fasterxml.jackson.jaxrs" % "jackson-jaxrs-json-provider"  % Jackson,
+    "com.sun.jersey"              % "jersey-bundle"                % Jersey exclude ("javax.ws.rs", "jsr311-api"),
+    "javax.servlet"               % "servlet-api"                  % ServletApi,
+    "org.eclipse.jgit"            % "org.eclipse.jgit"             % JGit,
+    "org.eclipse.jgit"            % "org.eclipse.jgit.http.server" % JGit,
+    "org.scalatest"               %% "scalatest"                   % Scalatest % Test
+  )
+
+  val markdown = Seq(
+    "org.scalatest" %% "scalatest" % Scalatest % Test
+  )
+
+  val core = Seq(
+    "com.typesafe.akka" %% "akka-actor" % Akka
+  )
+
+  val botWar = Seq.empty[ModuleID]
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -1,0 +1,11 @@
+object Versions {
+  val Akka              = "2.4.14"
+  val HttpClient        = "4.5.2"
+  val Jackson           = "2.8.5"
+  val Jersey            = "1.19.3"
+  val Jetty             = "7.6.21.v20160908"
+  val JGit              = "4.5.0.201609210915-r"
+  val ParserCombinators = "1.0.4"
+  val Scalatest         = "3.0.1"
+  val ServletApi        = "2.5"
+}

--- a/project/Versions.scala
+++ b/project/Versions.scala
@@ -8,4 +8,5 @@ object Versions {
   val ParserCombinators = "1.0.4"
   val Scalatest         = "3.0.1"
   val ServletApi        = "2.5"
+  val Specs2            = "3.8.6"
 }


### PR DESCRIPTION
Due to the multi-project build, I used a scala file under `project` instead `depend.sbt`.

Fixes #6.