### PR TITLE
Revert "Remove two more nulls"

### DIFF
--- a/Scalatron/src/scalatron/webServer/rest/resources/SourcesResource.scala
+++ b/Scalatron/src/scalatron/webServer/rest/resources/SourcesResource.scala
@@ -75,7 +75,7 @@ class SourcesResource extends ResourceWithUser {
             user.createVersion(versionLabel)
 
             val updatedSourceFiles = sourceFileUpdate.getFiles.map(sf =>
-              Scalatron.SourceFile(sf.fileName, sf.code))
+              Scalatron.SourceFile(sf.getFilename, sf.getCode))
             user.updateSourceFiles(updatedSourceFiles)
 
             // CBB: return information about the optionally created version to the caller as JSON (see 'create version' result)
@@ -154,5 +154,11 @@ object SourcesResource {
     }
   }
 
-  case class SourceFile(fileName: String, code: String)
+  case class SourceFile(var n: String, var c: String) {
+    def this() = this(null, null)
+    def getFilename = n
+    def getCode = c
+    def setFilename(name: String): Unit = { n = name }
+    def setCode(co: String): Unit = { c = co }
+  }
 }


### PR DESCRIPTION
This reverts commit 72137eb2616c8f4b26cbd2fe4786197679379ae6.

It actually just occurred to me that that change is not safe because the project uses java Rest APIs, that usually requires getters and setters to work properly. We need more tests in order to improve that code safely.